### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     name: nix build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -27,8 +27,8 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Cancel superseded runs on the same branch, but never on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    name: nix build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix build --print-build-logs
+
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix develop --command cargo fmt -- --check


### PR DESCRIPTION
Adds a CI workflow so dependency bumps can't merge without compiling.

## Jobs

Both run on pushes to `main`, on pull requests, and on manual dispatch.

- **`nix build`** — the flake is the build definition, so CI reproduces a local build exactly.
- **`cargo fmt`** — `nix develop --command cargo fmt -- --check`, against the repo's `rustfmt.toml`.

There is no test suite, so the build is the meaningful signal.

## Why this is worth having

It is the signal that was missing. The russh 0.61.1 bump in #14 was merged without ever being compiled: `Handle::data` had changed to take `impl Into<Bytes>`, and `main` failed to build from that merge until #17 landed. Nothing surfaced it, because there were no checks configured at all — #16's status rollup was simply empty.

## Notes on the design

**No nix store caching.** naersk keys its dependency derivation on `Cargo.lock`, so dependency-bump pull requests — precisely the case this CI exists to catch — would miss the cache anyway. Omitting it keeps the workflow simple with little cost.

**Linux only.** The flake handles darwin via `eachDefaultSystem` and the devShell carries `libiconv`, so a `macos-latest` leg could be added, but that build is unverified and would double runtime.

**`cancel-in-progress` excludes `main`,** so pushes to the default branch always produce a complete result.

## Verification

`actionlint` reports no findings. Both commands were run locally against this branch's merge base: `nix build` exits 0 and `cargo fmt --check` exits 0, so this run should come back green.